### PR TITLE
Return 404 for a non-existing study/calendar

### DIFF
--- a/src/main/java/io/redlink/more/data/controller/CalendarApiV1Controller.java
+++ b/src/main/java/io/redlink/more/data/controller/CalendarApiV1Controller.java
@@ -21,8 +21,8 @@ public class CalendarApiV1Controller implements CalendarApi {
 
     @Override
     public ResponseEntity<String> getStudyCalendar(Long studyId) {
-        return this.calendarService.getICalendarString(studyId)
-                .map(ResponseEntity::ok)
-                .orElseThrow(RuntimeException::new);
+        return ResponseEntity.of(
+                this.calendarService.getICalendarString(studyId)
+        );
     }
 }


### PR DESCRIPTION
Requesting the calendar for a non-existing study should result in a `404`-Response (not `5xx`)