### PR TITLE
#418: Fix event end time in CalendarService

### DIFF
--- a/src/main/java/io/redlink/more/data/service/CalendarService.java
+++ b/src/main/java/io/redlink/more/data/service/CalendarService.java
@@ -36,7 +36,7 @@ public class CalendarService {
             iCalEvent.addCategories("General");
             iCalEvent.setSummary("Study: " + study.title());
             iCalEvent.setDateStart(Date.from(study.plannedStartDate().atStartOfDay(TimeZone.getDefault().toZoneId()).toInstant()), false);
-            iCalEvent.setDateEnd(Date.from(study.endDate().atStartOfDay(TimeZone.getDefault().toZoneId()).toInstant()), false);
+            iCalEvent.setDateEnd(Date.from(study.endDate().atTime(23, 59).atZone(TimeZone.getDefault().toZoneId()).toInstant()), true);
             ical.addEvent(iCalEvent);
 
             final Instant start = shiftStartIfObservationAlreadyEnded(


### PR DESCRIPTION
Updated the event end time to set the datetime to 23:59 on the planned end date, ensuring that the full day is accounted for. The change also switches the boolean to 'true' for dateEnd to reflect this update, potentially impacting how end times are processed in the calendar. This adjustment should improve the accuracy of calendar entries for studies.