### PR TITLE
#549: Refactor SchedulerUtils method signatures to allow relative sch…

### DIFF
--- a/src/test/java/io/redlink/more/data/schedule/SchedulerUtilsTest.java
+++ b/src/test/java/io/redlink/more/data/schedule/SchedulerUtilsTest.java
@@ -10,8 +10,6 @@ package io.redlink.more.data.schedule;
 
 import io.redlink.more.data.model.Observation;
 import io.redlink.more.data.model.scheduler.*;
-import java.time.LocalTime;
-
 import org.apache.commons.lang3.Range;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -28,7 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.redlink.more.data.schedule.SchedulerUtils.shiftStartIfObservationAlreadyEnded;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,7 +42,7 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-23 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-11-23 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-11-23 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-24 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-11-24 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-25 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -70,7 +69,8 @@ public class SchedulerUtilsTest {
 
         actualValues = SchedulerUtils.parseToObservationSchedules(eventUntil, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2023-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
 
     @Test
     @DisplayName("Parsing daily event with count and until. Event duration is 30min")
@@ -78,7 +78,7 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-23 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-11-23 14:30:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-11-23 14:30:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-24 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-11-24 14:30:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-25 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -105,14 +105,16 @@ public class SchedulerUtilsTest {
 
         actualValues = SchedulerUtils.parseToObservationSchedules(eventUntil, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2023-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
+
     @Test
     @DisplayName("Parsing monthly event with until and byDay and bySetPos")
     void testParseMonthlyEvent() {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-01-02 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-01-02 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-02-06 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -130,7 +132,8 @@ public class SchedulerUtilsTest {
 
         List<Range<Instant>> actualValues = SchedulerUtils.parseToObservationSchedules(event, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2023-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
 
     @Test
     @DisplayName("Parsing monthly event with until and array of byDay and bySetPos")
@@ -138,21 +141,21 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-06 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-12-06 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-07 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-12-07 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
 
         expectedValues.add(Range.of(LocalDateTime.parse("2023-01-02 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2023-01-02 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2023-01-02 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-01-03 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-01-03 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-01-04 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-01-04 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
 
         expectedValues.add(Range.of(LocalDateTime.parse("2023-02-01 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2023-02-01 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2023-02-01 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-02-06 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-02-06 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-02-07 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -169,7 +172,8 @@ public class SchedulerUtilsTest {
                         .setCount(9));
         List<Range<Instant>> actualValues = SchedulerUtils.parseToObservationSchedules(event, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2023-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
 
     @Test
     @DisplayName("Parsing weekly event with count")
@@ -177,7 +181,7 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-23 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-11-23 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-11-23 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-11-30 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-11-30 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-07 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -193,7 +197,8 @@ public class SchedulerUtilsTest {
                         .setCount(3));
         List<Range<Instant>> actualValues = SchedulerUtils.parseToObservationSchedules(event, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2023-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
 
     @Test
     @DisplayName("Parsing yearly event with count")
@@ -201,7 +206,7 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2024-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -218,7 +223,8 @@ public class SchedulerUtilsTest {
                         .setCount(3));
         List<Range<Instant>> actualValues = SchedulerUtils.parseToObservationSchedules(event, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2030-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
 
     @Test
     @DisplayName("Parsing yearly event with count and bySetPos")
@@ -226,7 +232,7 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-12-04 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-12-04 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2024-12-02 14:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -244,7 +250,8 @@ public class SchedulerUtilsTest {
                         .setCount(3));
         List<Range<Instant>> actualValues = SchedulerUtils.parseToObservationSchedules(event, Instant.parse("2022-10-01T00:00:00.000Z"), Instant.parse("2030-10-01T00:00:00.000Z"));
         assertArrayEquals(Arrays.stream(expectedValues.toArray()).map(Object::toString).toArray(),
-                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());    }
+                Arrays.stream(actualValues.toArray()).map(Object::toString).toArray());
+    }
 
     @Test
     @DisplayName("Parsing yearly event with count and bySetPos and byDays")
@@ -252,17 +259,17 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-06 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-12-06 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
 
         expectedValues.add(Range.of(LocalDateTime.parse("2023-12-04 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2023-12-04 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2023-12-04 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2023-12-05 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2023-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
 
         expectedValues.add(Range.of(LocalDateTime.parse("2024-12-02 14:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2024-12-02 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2024-12-02 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2024-12-03 14:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2024-12-03 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
 
@@ -287,7 +294,7 @@ public class SchedulerUtilsTest {
         List<Range<Instant>> expectedValues = new ArrayList<>();
 
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 15:00:00", formatter).toInstant(ZoneOffset.UTC)
-                ,LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
+                , LocalDateTime.parse("2022-12-05 16:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 17:00:00", formatter).toInstant(ZoneOffset.UTC),
                 LocalDateTime.parse("2022-12-05 18:00:00", formatter).toInstant(ZoneOffset.UTC)));
         expectedValues.add(Range.of(LocalDateTime.parse("2022-12-05 19:00:00", formatter).toInstant(ZoneOffset.UTC),
@@ -310,19 +317,18 @@ public class SchedulerUtilsTest {
     void testRelativeEvent() {
         RelativeEvent event = new RelativeEvent()
                 .setDtstart(
-                    new RelativeDate()
-                            .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY))
-                            .setTime(LocalTime.parse("10:00"))
+                        new RelativeDate()
+                                .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY))
+                                .setTime(LocalTime.parse("10:00"))
                 ).setDtend(
-                    new RelativeDate()
-                            .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY))
-                            .setTime(LocalTime.parse("11:30"))
+                        new RelativeDate()
+                                .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY))
+                                .setTime(LocalTime.parse("11:30"))
                 );
 
-        Instant start = Instant.ofEpochSecond(1700118000); // Thursday, 30. November 2023 00:00:00
-        Instant maxEnd = Instant.ofEpochSecond(1701302400); // Thursday, 16. November 2023 07:00:00
+        Instant start = Instant.ofEpochSecond(1700118000); // Thursday, 16. November 2023 07:00:00
 
-        List<Range<Instant>> events =  SchedulerUtils.parseToObservationSchedulesForRelativeEvent(event, start, maxEnd);
+        List<Range<Instant>> events = SchedulerUtils.parseToObservationSchedulesForRelativeEvent(event, start);
         Assertions.assertEquals(1, events.size());
     }
 
@@ -345,9 +351,8 @@ public class SchedulerUtilsTest {
                 );
 
         Instant start = Instant.ofEpochSecond(1700118000); // Thursday, 16. November 2023 07:00:00
-        Instant maxEnd = Instant.ofEpochSecond(1701302400); // Thursday, 30. November 2023 00:00:00
 
-        List<Range<Instant>> events =  SchedulerUtils.parseToObservationSchedulesForRelativeEvent(event, start, maxEnd);
+        List<Range<Instant>> events = SchedulerUtils.parseToObservationSchedulesForRelativeEvent(event, start);
         Assertions.assertEquals(5, events.size());
     }
 
@@ -370,10 +375,9 @@ public class SchedulerUtilsTest {
                 );
 
         Instant start = Instant.ofEpochSecond(1700118000); // Thursday, 16. November 2023 07:00:00
-        Instant maxEnd = Instant.ofEpochSecond(1701302400); // Thursday, 30. November 2023 00:00:00
 
-        List<Range<Instant>> events =  SchedulerUtils.parseToObservationSchedulesForRelativeEvent(event, start, maxEnd);
-        Assertions.assertEquals(5, events.size());
+        List<Range<Instant>> events = SchedulerUtils.parseToObservationSchedulesForRelativeEvent(event, start);
+        Assertions.assertEquals(34, events.size());
     }
 
     @Test


### PR DESCRIPTION
…edules to go beyond the planned study end date

Refactored methods in SchedulerUtils to remove the redundant 'maxEnd' parameter, simplifying function calls and streamlining logic. Modified related calls in StudyRepository to align with the updated method signatures. Additionally, adjusted imports and improved test formatting for consistency and readability across files.