### PR TITLE
Fix parameter order in updateParticipantStatus call

### DIFF
--- a/src/main/java/io/redlink/more/data/repository/StudyRepository.java
+++ b/src/main/java/io/redlink/more/data/repository/StudyRepository.java
@@ -318,7 +318,7 @@ public class StudyRepository {
                     final long studyId = rs.getLong("study_id");
                     final int participantId = rs.getInt("participant_id");
                     withdrawConsent(studyId, participantId);
-                    updateParticipantStatus(studyId, participantId, 0,
+                    updateParticipantStatus(studyId, 0, participantId,
                             "active", "abandoned");
                 }
         );


### PR DESCRIPTION
Corrected the argument order in the updateParticipantStatus method to match its expected signature. This ensures proper status updates when withdrawing participant consent.