### PR TITLE
chore: build local docker with correct arch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <testcontainers.version>1.20.6</testcontainers.version>
 
         <docker.namespace>more-project</docker.namespace>
+        <docker.localArch>${os.arch}</docker.localArch>
 
         <start-class>io.redlink.more.data.MoreDataGatewayApplication</start-class>
     </properties>
@@ -272,6 +273,16 @@
                         <id>jib-install</id>
                         <phase>install</phase>
                         <goals><goal>dockerBuild</goal></goals>
+                        <configuration>
+                            <from>
+                                <platforms>
+                                    <platform>
+                                        <architecture>${docker.localArch}</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>jib-package</id>
@@ -599,7 +610,18 @@
                 <skipTests>true</skipTests>
                 <skipITs>true</skipITs>
             </properties>
-
+        </profile>
+        <profile>
+            <id>apple-silicon</id>
+            <activation>
+                <property>
+                    <name>os.arch</name>
+                    <value>aarch64</value>
+                </property>
+            </activation>
+            <properties>
+                <docker.localArch>arm64</docker.localArch>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
By default, architecture used in docker build is `amd64` - but on Apple-Silicon `arm64` should be used...