### PR TITLE
#281 data health state in api

### DIFF
--- a/src/main/java/io/redlink/more/data/controller/participantportal/ParticipantPortalController.java
+++ b/src/main/java/io/redlink/more/data/controller/participantportal/ParticipantPortalController.java
@@ -6,9 +6,11 @@ import io.redlink.more.data.api.participant.v1.webservices.AuthorizationApi;
 import io.redlink.more.data.api.participant.v1.webservices.ConfigurationApi;
 import io.redlink.more.data.controller.transformer.ParticipantPortalTransformer;
 import io.redlink.more.data.exception.NotAuthorizedException;
+import io.redlink.more.data.model.DataHealth;
 import io.redlink.more.data.model.ParticipantConsent;
 import io.redlink.more.data.model.RoutingInfo;
 import io.redlink.more.data.service.ApplicationAccessService;
+import io.redlink.more.data.service.DataHealthService;
 import io.redlink.more.data.service.StudyService;
 import io.redlink.more.data.util.ParticipantUtils;
 import io.redlink.more.data.util.StudyParticipantUserDetails;
@@ -33,6 +35,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -47,10 +50,15 @@ public class ParticipantPortalController implements AuthorizationApi, Configurat
 
     private final ApplicationAccessService applicationAccessService;
     private final StudyService studyService;
+    private final DataHealthService dataHealthService;
 
-    ParticipantPortalController(ApplicationAccessService applicationAccessService, StudyService studyService) {
+    ParticipantPortalController(
+            ApplicationAccessService applicationAccessService,
+            StudyService studyService,
+            DataHealthService dataHealthService) {
         this.applicationAccessService = applicationAccessService;
         this.studyService = studyService;
+        this.dataHealthService = dataHealthService;
     }
 
     @Override
@@ -149,15 +157,33 @@ public class ParticipantPortalController implements AuthorizationApi, Configurat
         RoutingInfo routingInfo = validateRoutingInfo()
                 .orElseThrow(NotAuthorizedException::new);
 
-        var studyData = studyService.getStudy(routingInfo);
-        return studyData
-                //only return data for active and paused studies
-                .filter(sd -> sd.getLeft().active() || "paused".equals(sd.getLeft().studyState()))
-                .map(studyListPair ->
-                        ResponseEntity.ok(ParticipantPortalTransformer.toDTO(studyListPair.getLeft(), studyListPair.getRight())))
-                .orElseGet(() ->
-                        ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        var studyData = studyService.getStudy(routingInfo)
+                .filter(sd -> sd.getLeft().active() || "paused".equals(sd.getLeft().studyState()));
+        if(studyData.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        var studyDTO = ParticipantPortalTransformer.toDTO(studyData.get().getLeft(), studyData.get().getRight());
+
+        //add the dataHealth information to the studyDTO (Not done in Transformer as this need calls to the dataHealthService)
+        studyDTO.getObservations().forEach(observation ->
+                observation.getSchedule().forEach(observationSchedule -> {
+                        DataHealth dataHealth;
+                        if(observationSchedule.getStart().isBefore(Instant.now())) {
+                            dataHealth = dataHealthService.checkDataHealth(
+                                    routingInfo.studyId(),
+                                    routingInfo.participantId(),
+                                    Integer.parseInt(observation.getObservationId()), //ObservationId in the API is a String :(
+                                    observationSchedule.getStart());
+                        } else {
+                            dataHealth = null; //no need to check for existing data if the observation has not yet started
+                        }
+                        observationSchedule.setDataHealth(ParticipantPortalTransformer.toDataHealStateDto(dataHealth));
+                }));
+
+        return ResponseEntity.ok(studyDTO);
     }
+
+
 
 
     private Optional<RoutingInfo> validateRoutingInfo(){

--- a/src/main/java/io/redlink/more/data/controller/transformer/ParticipantPortalTransformer.java
+++ b/src/main/java/io/redlink/more/data/controller/transformer/ParticipantPortalTransformer.java
@@ -1,23 +1,30 @@
 package io.redlink.more.data.controller.transformer;
 
 import io.redlink.more.data.api.participant.v1.model.ContactInfoDTO;
+import io.redlink.more.data.api.participant.v1.model.DataHealthStateDTO;
 import io.redlink.more.data.api.participant.v1.model.ObservationDTO;
 import io.redlink.more.data.api.participant.v1.model.ObservationScheduleDTO;
 import io.redlink.more.data.api.participant.v1.model.SimpleParticipantDTO;
 import io.redlink.more.data.api.participant.v1.model.StudyDTO;
 import io.redlink.more.data.model.Contact;
+import io.redlink.more.data.model.DataHealth;
 import io.redlink.more.data.model.Observation;
 import io.redlink.more.data.model.ParticipantObservationSeed;
 import io.redlink.more.data.model.SimpleParticipant;
 import io.redlink.more.data.model.Study;
 import io.redlink.more.data.util.SchedulerUtils;
 import org.apache.commons.lang3.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 public final class ParticipantPortalTransformer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParticipantPortalTransformer.class);
+
     public static StudyDTO toDTO(Study study, List<ParticipantObservationSeed> seeds) {
         return new StudyDTO()
                 .active(study.active())
@@ -107,5 +114,28 @@ public final class ParticipantPortalTransformer {
         return new ObservationScheduleDTO()
                 .start(schedule.getMinimum())
                 .end(schedule.getMaximum());
+    }
+
+    public static DataHealthStateDTO toDataHealStateDto(DataHealth dataHealth) {
+        DataHealthStateDTO dataHealhState;
+        if(dataHealth == null) {
+            dataHealhState = null;
+        } else if(!dataHealth.valid()) {
+            dataHealhState = DataHealthStateDTO.INVALID;
+        } else {
+            switch (dataHealth.state()) {
+                case PARTIAL, INCOMPLETE -> dataHealhState = DataHealthStateDTO.INCOMPLETE;
+                case COMPLETE -> dataHealhState = DataHealthStateDTO.COMPLETED;
+                default -> {
+                    try {
+                        dataHealhState = DataHealthStateDTO.fromValue(dataHealth.state().getValue());
+                    } catch (IllegalArgumentException e) {
+                        LOG.error("Unexpected data health state {}", dataHealth.state(), e);
+                        dataHealhState = null;
+                    }
+                }
+            }
+        }
+        return dataHealhState;
     }
 }

--- a/src/main/resources/openapi/BaseComponents.yaml
+++ b/src/main/resources/openapi/BaseComponents.yaml
@@ -106,6 +106,9 @@ components:
               end:
                 type: string
                 format: date-time
+              dataHealth:
+                $ref: '#/components/schemas/DataHealthState'
+
         required:
           type: boolean
           default: true
@@ -135,6 +138,22 @@ components:
         but that's not guaranteed.
       type: integer
       format: int64
+
+    DataHealthState:
+      type: string
+      description: >
+        Data Health states:
+          * `completed` - The expected data for the observation schedule are completely availanble
+          * `incomplete` - Data for the observation schedule are available and valid, but more data is expected
+          * `missing` - No data for the observation schedule is available
+          * `invalid` - Data is available, but the data is not valid (e.g. multiple answers for a survey; 
+             wrong data format; missing required information)
+      enum:
+        - completed
+        - incomplete
+        - missing
+        - invalid
+      default: missing
 
     StudyConsent:
       type: object

--- a/src/test/java/io/redlink/more/data/controller/participantportal/ParticipantPortalControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/participantportal/ParticipantPortalControllerTest.java
@@ -4,10 +4,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.redlink.more.data.api.participant.v1.model.StudyConsentDTO;
 import io.redlink.more.data.configuration.SecurityConfig;
 import io.redlink.more.data.model.Contact;
+import io.redlink.more.data.model.DataHealth;
+import io.redlink.more.data.model.Observation;
+import io.redlink.more.data.model.ObservationDataState;
 import io.redlink.more.data.model.RoutingInfo;
 import io.redlink.more.data.model.SimpleParticipant;
 import io.redlink.more.data.model.Study;
+import io.redlink.more.data.model.scheduler.Duration;
+import io.redlink.more.data.model.scheduler.Event;
+import io.redlink.more.data.model.scheduler.RelativeDate;
+import io.redlink.more.data.model.scheduler.RelativeEvent;
+import io.redlink.more.data.model.scheduler.RelativeRecurrenceRule;
+import io.redlink.more.data.model.scheduler.ScheduleEvent;
 import io.redlink.more.data.service.ApplicationAccessService;
+import io.redlink.more.data.service.DataHealthService;
 import io.redlink.more.data.service.GatewayUserDetailService;
 import io.redlink.more.data.service.LoginTokenService;
 import io.redlink.more.data.service.RegistrationService;
@@ -27,13 +37,19 @@ import org.springframework.security.web.context.HttpSessionSecurityContextReposi
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -41,6 +57,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +65,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ParticipantPortalController.class)
@@ -78,6 +96,9 @@ class ParticipantPortalControllerTest {
 
     @MockitoBean
     private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private DataHealthService dataHealthService;
 
     @Test
     void testParticipantLoginSetsSession() throws Exception {
@@ -223,7 +244,7 @@ class ParticipantPortalControllerTest {
                 new Contact("Inst", "Person", "email", "phone"),
                 LocalDate.now(), LocalDate.now(), LocalDate.now().plusDays(10),
                 Collections.emptyList(), Instant.now(), Instant.now(),
-                new SimpleParticipant(participantId, "alias", Instant.now(), Instant.now().plus(Duration.ofDays(10))));
+                new SimpleParticipant(participantId, "alias", Instant.now(), Instant.now().plus(10, ChronoUnit.DAYS)));
 
         when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
         when(applicationAccessService.hasConsent(routingInfo)).thenReturn(false);
@@ -296,23 +317,143 @@ class ParticipantPortalControllerTest {
 
     @Test
     void testGetStudyConfigurationSuccess() throws Exception {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.HOURS);
         long studyId = 12L;
+        var studyStart = LocalDate.now().minusDays(1);
+        var studyEnd = LocalDate.now().plusDays(14);
+
+
         int participantId = 9;
+        Instant participantStart = now.minus(26, ChronoUnit.HOURS);
+        Instant participantEnd = now.plus(10, ChronoUnit.DAYS);
+
+        Instant absStart = now.minus(1, ChronoUnit.HOURS);
+        Instant absEnd = now.plus(3, ChronoUnit.HOURS);
+        ZoneId zone = ZoneId.of("Europe/Vienna");
+
         RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
         StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);
+        var observation1 = new Observation(1, null, "observation 1", "type", "participant info",
+                null,
+                new Event().setDateStart(absStart).setDateEnd(absEnd),
+                null, null, //created, modified
+                false, false, false, Set.of());
+        var observation2 = new Observation(2, null, "observation 2", "type", "participant info",
+                null,
+                new RelativeEvent()
+                        .setDtstart(new RelativeDate()
+                                .setTime(LocalTime.from(absStart.atZone(zone)))
+                                .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY)))
+                        .setDtend(new RelativeDate()
+                                .setTime(LocalTime.from(absEnd.atZone(zone)))
+                                .setOffset(new Duration().setValue(1).setUnit(Duration.Unit.DAY)))
+                        .setRrrule(new RelativeRecurrenceRule()
+                                .setFrequency(new Duration().setValue(1).setUnit(Duration.Unit.DAY))
+                                .setEndAfter(new Duration().setValue(8).setUnit(Duration.Unit.DAY))),
+                now.minus(1,ChronoUnit.DAYS),
+                now.minus(1,ChronoUnit.DAYS),
+                false, false, false, Set.of());
         Study study = new Study(studyId, "Title", true, "Info", "Finish", "active", "Consent",
                 new Contact("Inst", "Person", "email", "phone"),
-                LocalDate.now(), LocalDate.now(), LocalDate.now().plusDays(10),
-                Collections.emptyList(), Instant.now(), Instant.now(),
-                new SimpleParticipant(participantId, "alias", Instant.now(), Instant.now().plus(Duration.ofDays(10))));
+                studyStart, studyStart, studyEnd,
+                List.of(observation1, observation2), Instant.now(), Instant.now(),
+                new SimpleParticipant(participantId, "alias", participantStart, participantEnd));
 
         when(studyService.getRoutingInfo(studyId, participantId)).thenReturn(Optional.of(routingInfo));
         when(studyService.getStudyState(studyId)).thenReturn(Optional.of("active"));
         when(studyService.getStudy(routingInfo)).thenReturn(Optional.of(Pair.of(study, Collections.emptyList())));
+        when(dataHealthService.checkDataHealth(studyId, participantId, observation1.observationId(), absStart)).thenReturn(
+                new DataHealth(true, ObservationDataState.COMPLETE)
+        );
+        when(dataHealthService.checkDataHealth(studyId, participantId, observation2.observationId(), absStart)).thenReturn(
+                new DataHealth(false, ObservationDataState.COMPLETE)
+        );
+        //when(dataHealthService.checkDataHealth(eq(studyId), eq(participantId), anyInt(), any())).thenReturn(
+        //        new DataHealth(true, ObservationDataState.MISSING)
+        //);
 
         mockMvc.perform(get("/participant-portal/api/v1/config/study")
                         .with(user(userDetails)))
-                .andExpect(status().isOk());
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(true))
+                .andExpect(jsonPath("$.studyState").value("active"))
+
+                .andExpect(jsonPath("$.participant.id").value(9))
+                .andExpect(jsonPath("$.participant.alias").value("alias"))
+
+                .andExpect(jsonPath("$.studyTitle").value("Title"))
+                .andExpect(jsonPath("$.participantInfo").value("Info"))
+                .andExpect(jsonPath("$.consentInfo").value("Consent"))
+                .andExpect(jsonPath("$.finishText").value("Finish"))
+
+                .andExpect(jsonPath("$.contact.institute").value("Inst"))
+                .andExpect(jsonPath("$.contact.person").value("Person"))
+                .andExpect(jsonPath("$.contact.email").value("email"))
+                .andExpect(jsonPath("$.contact.phoneNumber").value("phone"))
+
+                // Study dates - using variables from the test
+                .andExpect(jsonPath("$.start").value(studyStart.toString()))
+                .andExpect(jsonPath("$.end").value(studyEnd.toString()))
+
+                // === Observation 1 ===
+                .andExpect(jsonPath("$.observations[0].observationId").value("1"))
+                .andExpect(jsonPath("$.observations[0].observationType").value("type"))
+                .andExpect(jsonPath("$.observations[0].observationTitle").value("observation 1"))
+                .andExpect(jsonPath("$.observations[0].participantInfo").value("participant info"))
+                .andExpect(jsonPath("$.observations[0].required").value(true))
+                .andExpect(jsonPath("$.observations[0].hidden").value(false))
+                .andExpect(jsonPath("$.observations[0].noSchedule").value(false))
+                .andExpect(jsonPath("$.observations[0].reminder").value(false))
+                .andExpect(jsonPath("$.observations[0].version").isEmpty())           // null in JSON
+                .andExpect(jsonPath("$.observations[0].configuration").isEmpty())
+
+                // Schedule for observation 1 (single absolute event)
+                .andExpect(jsonPath("$.observations[0].schedule[0].start").value(absStart.toString()))
+                .andExpect(jsonPath("$.observations[0].schedule[0].end").value(absEnd.toString()))
+                .andExpect(jsonPath("$.observations[0].schedule[0].dataHealth").value("completed"))
+
+                // === Observation 2 ===
+                .andExpect(jsonPath("$.observations[1].observationId").value("2"))
+                .andExpect(jsonPath("$.observations[1].observationType").value("type"))
+                .andExpect(jsonPath("$.observations[1].observationTitle").value("observation 2"))
+                .andExpect(jsonPath("$.observations[1].participantInfo").value("participant info"))
+                .andExpect(jsonPath("$.observations[1].required").value(true))
+                .andExpect(jsonPath("$.observations[1].hidden").value(false))
+                .andExpect(jsonPath("$.observations[1].noSchedule").value(false))
+                .andExpect(jsonPath("$.observations[1].reminder").value(false))
+                .andExpect(jsonPath("$.observations[1].configuration").isEmpty())
+
+                // Schedule entries for observation 2
+                .andExpect(jsonPath("$.observations[1].schedule.length()").value(8))
+
+                // First schedule entry (should be completed according to the mocked dataHealth)
+                .andExpect(jsonPath("$.observations[1].schedule[0].start").value(absStart.minus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[0].end").value(absEnd.minus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[0].dataHealth").isEmpty())  // from your mock
+
+                // The rest of the recurring entries (dataHealth is null or "invalid" as in the example JSON)
+                .andExpect(jsonPath("$.observations[1].schedule[1].start").value(absStart.toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[1].end").value(absEnd.toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[1].dataHealth").value("invalid"))
+                .andExpect(jsonPath("$.observations[1].schedule[2].start").value(absStart.plus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[2].end").value(absEnd.plus(1, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[2].dataHealth").isEmpty())
+                .andExpect(jsonPath("$.observations[1].schedule[3].start").value(absStart.plus(2, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[3].end").value(absEnd.plus(2, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[3].dataHealth").isEmpty())
+                .andExpect(jsonPath("$.observations[1].schedule[4].start").value(absStart.plus(3, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[4].end").value(absEnd.plus(3, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[4].dataHealth").isEmpty())
+                .andExpect(jsonPath("$.observations[1].schedule[5].start").value(absStart.plus(4, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[5].end").value(absEnd.plus(4, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[5].dataHealth").isEmpty())
+                .andExpect(jsonPath("$.observations[1].schedule[6].start").value(absStart.plus(5, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[6].end").value(absEnd.plus(5, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[6].dataHealth").isEmpty())
+                .andExpect(jsonPath("$.observations[1].schedule[7].start").value(absStart.plus(6, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[7].end").value(absEnd.plus(6, ChronoUnit.DAYS).toString()))
+                .andExpect(jsonPath("$.observations[1].schedule[7].dataHealth").isEmpty());
     }
 
     @Test

--- a/src/test/java/io/redlink/more/data/controller/participantportal/ParticipantPortalControllerTest.java
+++ b/src/test/java/io/redlink/more/data/controller/participantportal/ParticipantPortalControllerTest.java
@@ -329,7 +329,8 @@ class ParticipantPortalControllerTest {
 
         Instant absStart = now.minus(1, ChronoUnit.HOURS);
         Instant absEnd = now.plus(3, ChronoUnit.HOURS);
-        ZoneId zone = ZoneId.of("Europe/Vienna");
+
+        ZoneId zone = ZoneId.systemDefault();
 
         RoutingInfo routingInfo = new RoutingInfo(studyId, participantId, OptionalInt.empty(), Set.of(), true, true);
         StudyParticipantUserDetails userDetails = new StudyParticipantUserDetails(studyId, participantId, null);


### PR DESCRIPTION
This adds support for the data health state to the Participant Portal API

Example:

```json
{
	"active": true,
	"studyState": "active",
	"participant": {
		"id": 9,
		"alias": "alias"
	},
	"studyTitle": "Title",
	"participantInfo": "Info",
	"consentInfo": "Consent",
	"finishText": "Finish",
	"start": "2026-04-12",
	"end": "2026-04-27",
	"observations": [
		{
			"observationId": "1",
			"observationType": "type",
			"observationTitle": "observation 1",
			"participantInfo": "participant info",
			"schedule": [
				{
					"start": "2026-04-13T09:00:00Z",
					"end": "2026-04-13T13:00:00Z",
					"dataHealth": "completed"
				}
			],
			"required": true,
			"hidden": false,
			"noSchedule": false,
			"reminder": false,
			"version": null,
			"configuration": null
		},
[..]
```